### PR TITLE
OSX fixes

### DIFF
--- a/src/jackdriver.c
+++ b/src/jackdriver.c
@@ -454,30 +454,44 @@ void queue_midi(void* seqq, uint8_t msg[])
     // At least with JackOSX, Jack will transmit the bytes verbatim, so make
     // sure that we look at the status byte and trim the message accordingly,
     // in order not to transmit any invalid MIDI data.
-    switch (msg[0] & 0xf0) {
-    case 0x80: case 0x90: case 0xa0: case 0xb0: case 0xe0:
-      break; // 2 data bytes
-    case 0xc0: case 0xd0:
-      ev.len = 2; // 1 data byte
-      break;
+    switch (msg[0] & 0xf0)
+    {
+    case 0x80:
+    case 0x90:
+    case 0xa0:
+    case 0xb0:
+    case 0xe0:
+        break; // 2 data bytes
+    case 0xc0:
+    case 0xd0:
+        ev.len = 2; // 1 data byte
+        break;
     case 0xf0: // system message
-      switch (msg[0]) {
-      case 0xf2:
-	break; // 2 data bytes
-      case 0xf1: case 0xf3:
-	ev.len = 2; // 1 data byte
-      case 0xf6: case 0xf8: case 0xf9:
-      case 0xfa: case 0xfb: case 0xfc:
-      case 0xfe: case 0xff:
-	ev.len = 1; // no data byte
-	break;
-      default:
-	// ignore unknown (most likely sysex)
-	return;
-      }
-      break;
+        switch (msg[0])
+        {
+        case 0xf2:
+            break; // 2 data bytes
+        case 0xf1:
+        case 0xf3:
+            ev.len = 2; // 1 data byte
+            break;
+        case 0xf6:
+        case 0xf8:
+        case 0xf9:
+        case 0xfa:
+        case 0xfb:
+        case 0xfc:
+        case 0xfe:
+        case 0xff:
+            ev.len = 1; // no data byte
+            break;
+        default:
+            // ignore unknown (most likely sysex)
+            return;
+        }
+        break;
     default:
-      return; // not a valid MIDI message, bail out
+        return; // not a valid MIDI message, bail out
     }
 
     ev.data[0] = msg[0];

--- a/src/jackdriver.c
+++ b/src/jackdriver.c
@@ -450,6 +450,36 @@ void queue_midi(void* seqq, uint8_t msg[])
     MidiMessage ev;
     JACK_SEQ* seq = (JACK_SEQ*)seqq;
     ev.len = 3;
+
+    // At least with JackOSX, Jack will transmit the bytes verbatim, so make
+    // sure that we look at the status byte and trim the message accordingly,
+    // in order not to transmit any invalid MIDI data.
+    switch (msg[0] & 0xf0) {
+    case 0x80: case 0x90: case 0xa0: case 0xb0: case 0xe0:
+      break; // 2 data bytes
+    case 0xc0: case 0xd0:
+      ev.len = 2; // 1 data byte
+      break;
+    case 0xf0: // system message
+      switch (msg[0]) {
+      case 0xf2:
+	break; // 2 data bytes
+      case 0xf1: case 0xf3:
+	ev.len = 2; // 1 data byte
+      case 0xf6: case 0xf8: case 0xf9:
+      case 0xfa: case 0xfb: case 0xfc:
+      case 0xfe: case 0xff:
+	ev.len = 1; // no data byte
+	break;
+      default:
+	// ignore unknown (most likely sysex)
+	return;
+      }
+      break;
+    default:
+      return; // not a valid MIDI message, bail out
+    }
+
     ev.data[0] = msg[0];
     ev.data[1] = msg[1];
     ev.data[2] = msg[2];

--- a/src/pair.c
+++ b/src/pair.c
@@ -854,7 +854,7 @@ int get_pair_mapping(char* config, PAIR* p, int n)
                 p->osc_rangemax[i] = 0;
                 p->osc_const[i] = 0;
             }
-	    break;
+            break;
         }
         p->osc_val[i] = 0;
         p->osc_scale[i] = 1;
@@ -1610,9 +1610,17 @@ char * opcode2cmd(uint8_t opcode, uint8_t noteoff)
 void print_midi(PAIRHANDLE ph, uint8_t msg[])
 {
     PAIR* p = (PAIR*)ph;
+    int status = msg[0]&0xf0;
     if(p->raw_midi) // this needs special treatment
         printf("%s ( %i, %i, %i )", opcode2cmd(p->opcode,1), msg[0], msg[1], msg[2]);
+    else if (status == 0xc0 || status == 0xd0)
+    {
+        // single data byte
+        printf("%s ( %i, %i )", opcode2cmd(msg[0],1), msg[0]&0x0F, msg[1]);
+    }
     else
-        //TODO: make this variable number of args for program change etc
+    {
+        // anything else should have two data bytes
         printf("%s ( %i, %i, %i )", opcode2cmd(msg[0],1), msg[0]&0x0F, msg[1], msg[2]);
+    }
 }

--- a/src/pair.c
+++ b/src/pair.c
@@ -840,9 +840,22 @@ int get_pair_mapping(char* config, PAIR* p, int n)
     }
 
     //now go through OSC args
-    tmp = argnames;
+    tmp = strtok(argnames,",");
     for(i=0; i<p->argc_in_path + p->argc; i++)
     {
+        if(!tmp)
+        {
+            //underspecified, assume everything else is unused
+            for(; i<p->argc_in_path + p->argc; i++)
+            {
+                p->osc_val[i] = 0;
+                p->osc_scale[i] = 1;
+                p->osc_offset[i] = 0;
+                p->osc_rangemax[i] = 0;
+                p->osc_const[i] = 0;
+            }
+	    break;
+        }
         p->osc_val[i] = 0;
         p->osc_scale[i] = 1;
         p->osc_offset[i] = 0;
@@ -868,21 +881,7 @@ int get_pair_mapping(char* config, PAIR* p, int n)
             p->osc_const[i] = get_pair_arg_constant(tmp,&p->osc_val[i],&p->osc_rangemax[i]);
         }
         //next arg name
-        tmp = strchr(tmp,',');
-        if(!tmp)
-        {
-            //underspecified, assume everything else is unused
-            for(; i<p->argc_in_path + p->argc; i++)
-            {
-                p->osc_val[i] = 0;
-                p->osc_scale[i] = 1;
-                p->osc_offset[i] = 0;
-                p->osc_rangemax[i] = 0;
-                p->osc_const[i] = 0;
-            }
-        }
-
-        tmp++;//go to char after ','
+        tmp = strtok(NULL,",");
     }
     return 0;
 }

--- a/src/pair.c
+++ b/src/pair.c
@@ -105,16 +105,16 @@ void print_pair(PAIRHANDLE ph)
         if(i==p->argc+p->argc_in_path)
             printf("off");
     }
-    printf("(");
+    printf("( ");
 
     //global channel
     if(p->use_glob_chan)
-        printf(" channel");
+        printf("channel");
     //midi arg 0
     else if(p->midi_const[0] == 2)
-        printf(" %i-%i",p->midi_val[0], p->midi_rangemax[0]);
+        printf("%i-%i",p->midi_val[0], p->midi_rangemax[0]);
     else if(p->midi_const[0] == 1)
-        printf(" %i",p->midi_val[0]);
+        printf("%i",p->midi_val[0]);
     else
     {
         if(p->midi_map[0] != -1)
@@ -126,7 +126,7 @@ void print_pair(PAIRHANDLE ph)
                 printf(" + %.2f",p->midi_offset[0]);
         }
         else if(p->n>0)
-            printf(", y1");
+            printf("y1");
     }
 
     //midi arg1

--- a/src/pair.c
+++ b/src/pair.c
@@ -7,6 +7,7 @@
 #include<stdio.h>
 #include<stdlib.h>
 #include<string.h>
+#include<ctype.h>
 #include"pair.h"
 
 #include "ht_stuff.h"
@@ -551,17 +552,21 @@ int get_pair_osc_arg_index(char* varname, char* oscargs, uint8_t argc, uint8_t s
     return i;
 }
 
+//check whether the given string contains nothing but whitespace
 static int is_ws(const char *s)
 {
-    while(*s && *s == ' ') s++;
+    while(*s && isspace(*s)) s++;
     return *s==0;
 }
 
+//match the given string against a given operator symbol
+//checks that the string contains nothing but the operator symbol,
+//possibly surrounded by whitespace
 static int match_op(const char *s, char op)
 {
-    while(*s && *s == ' ') s++;
+    while(*s && isspace(*s)) s++;
     if (*s != op) return 0;
-    while(*++s && *s == ' ');
+    while(*++s && isspace(*s));
     return *s==0;
 }
 
@@ -637,6 +642,9 @@ int get_pair_arg_conditioning(char* arg, char* varname, float* _scale, float* _o
             {
                 scale *= -1;
             }
+            //if we come here, we failed to parse the pre conditioning; if
+            //it's just whitespace then we ignore it, otherwise there's a
+            //syntax error, so spit out an error message
             else if (!is_ws(pre))
             {
                 printf("\nERROR -failed to parse '%s'! nonsensical operator?\n", pre);
@@ -696,6 +704,9 @@ int get_pair_arg_conditioning(char* arg, char* varname, float* _scale, float* _o
             }
             break;
         default:
+            //if we come here, we failed to parse the post conditioning; if
+            //it's just whitespace then we ignore it, otherwise there's a
+            //syntax error, so spit out an error message
             if (!is_ws(post))
             {
                 printf("\nERROR -failed to parse '%s'! nonsensical operator?\n", post);

--- a/src/pair.c
+++ b/src/pair.c
@@ -741,12 +741,32 @@ int get_pair_mapping(char* config, PAIR* p, int n)
             printf("\nERROR in config line:\n%s -could not understand arg %i in midi command\n\n",config,i);
             return -1;
         }
-        else if(!strncmp(var,"channel",7))//check if its the global channel keyword
+        else if(!strcmp(var,"channel"))//check if its the global channel keyword
         {
+	    if (i != 0)
+	    {
+		printf("\nERROR in config line:\n%s -special channel variable used in wrong position (arg %i) in midi command\n\n",config,i);
+		return -1;
+	    }
+	    if (p->midi_scale[i] != 1.0 || p->midi_offset[i] != 0.0)
+	    {
+		printf("\nERROR in config line:\n%s -scaling of special channel variable not supported\n\n",config);
+		return -1;
+	    }
             p->use_glob_chan = 1;//should these global vars be able to be scaled?
         }
-        else if(!strncmp(var,"velocity",8))
+        else if(!strcmp(var,"velocity"))
         {
+	    if (i != 2)
+	    {
+		printf("\nERROR in config line:\n%s -special velocity variable used in wrong position (arg %i) in midi command\n\n",config,i);
+		return -1;
+	    }
+	    if (p->midi_scale[i] != 1.0 || p->midi_offset[i] != 0.0)
+	    {
+		printf("\nERROR in config line:\n%s -scaling of special velocity variable not supported\n\n",config);
+		return -1;
+	    }
             p->use_glob_vel = 1;
         }
         else


### PR DESCRIPTION
This fixes padding with extra null bytes in osc2midi's MIDI output, which JackOSX/CoreMidi doesn't like. Output MIDI messages are now trimmed to the proper byte count, and invalid MIDI data is ignored.

For some reason, the extra bytes don't cause issues on Linux -- maybe the ALSA layer eliminates them when hooking up osc2midi to ALSA MIDI applications via a2jmidid? But on OSX this fix is definitely needed, otherwise MIDI applications may misbehave, or at least spit out warnings about invalid MIDI data. And of course the fix works on Linux, too.
