### PR TITLE
improved syntax checking of map files

### DIFF
--- a/maps/syntax.omm
+++ b/maps/syntax.omm
@@ -1,0 +1,24 @@
+# This is *not* a working map file. It's full of syntax errors and is not
+# intended to be used for any purpose other than a regression test for the
+# osc2midi parser. A proper implementation should find an error in each of the
+# following lines. (Older versions of osc2midi will happily parse some of
+# these and produce bogus mappings instead.)
+/1, : noteon( 0, 60, 127 );
+/1 : noteon( 0, 60, 127 );
+/1: noteon( 0, 60, 127 );
+/1/fader1 f, 1- : controlchange( 0, 1, 127*val );
+/1/fader1 f, val- : controlchange( 0, 1, 127*val );
+/1/fader1 f, +val : controlchange( 0, 1, 127*val );
+/1/fader2 f, val : controlchange( 0, 1-, 127*val );
+/1/fader2 f, val : controlchange( 0, 1, 127* );
+/1/fader2 f, val : controlchange( 0, 1, *val );
+/2 , : noteon( 0, 61, 127+ );
+/2/multipush1/1/1 f, val : controlchange( );
+/2/multipush1/1/1 f, val : controlchange
+/2/multipush1/2/1 f, val : controlchange( 0, , 127*val );
+/2/multipush1/3/1 f, val : controlchange( 0, 1-3, 127*val );
+/2/multipush1/1/2 f, val controlchange( 0, 4, 127*val );
+/2/multipush1/2/2 f, val : controlchange( 0, 5, 127* 
+/2/multipush1/3/2 f, val : controlchange( 0, 6, 127*val ); junk
+/2/xy1 ff, 5+-3,  : controlchange( 1, 1, 127*val );
+/2/xy1 ff, , *-3 : controlchange( 1, 2, 127*val );

--- a/src/converter.h
+++ b/src/converter.h
@@ -16,6 +16,8 @@ typedef struct _CONVERTER
     uint8_t mon_mode;
     uint8_t multi_match;
     int8_t  convert; //0 = both, 1 = o2m, -1 = m2o
+    uint8_t dry_run;
+    int errors;
 
     uint16_t npairs;
     PAIRHANDLE* p;

--- a/src/pair.c
+++ b/src/pair.c
@@ -240,9 +240,9 @@ void rm_whitespace(char* str)
 
    arg ::= [ pre ] var [ post ] | number
 
-   pre ::= '-' | [ number addop ] [ number '*' ]
+   pre ::= '-' | [ number add-op ] [ number '*' ]
 
-   post ::= [ mulop number ] [ addop number ]
+   post ::= [ mul-op number ] [ add-op number ]
 
    add-op ::= '+' | '-'
 


### PR DESCRIPTION
Even after the parser improvements in my previous pull request osc2midi would still happily accept some bogus lines such as:

```
/2/multipush1/2/2 f, val : controlchange( 0, 5, 127*
```

Therefore I decided to write an improved parser which is in this pull request. It is implemented as a separate config_check() routine which is called to check the syntax beforehand, do that well and do nothing else. The rest of the parsing is done as before, so there's no change of code in the other semantic routines which do the actual processing.

config_check() implements a full-blown parser for omm rules, so it checks for syntax errors much more reliably than the bunch of scanf's which is used in the semantic routines. (See the comments next to the routine for the EBNF grammar which is implemented.)

A regression test is included as maps/syntax.omm. This is _not_ a working map file. It's full of syntax errors and is not intended to be used for any purpose other than a regression test for the osc2midi parser. A proper implementation should find an error in each of the rules in this file, and check_config() does. On the other hand, it also parses and accepts all the other maps included with osc2midi as well as my own maps distributed with osc2midi-utils.

I've also added a new "dry run" option `-n` which lets me run syntax checks more conveniently and see the number of detected errors at a glace. It is used like this:

```
osc2midi -n -m syntax.omm
```

**Note:** The parser contains non-local exits (even gotos) galore (mostly error exits), but I consider these customary style when writing parsers. ;-)
