### PR TITLE
bugfixes in rule checker

### DIFF
--- a/maps/syntax.omm
+++ b/maps/syntax.omm
@@ -13,10 +13,10 @@
 /1/fader2 f, val : controlchange( 0, 1, 127* );
 /1/fader2 f, val : controlchange( 0, 1, *val );
 /2 , : noteon( 0, 61, 127+ );
-/2/multipush1/1/1 f, val : controlchange( );
 /2/multipush1/1/1 f, val : controlchange
-/2/multipush1/2/1 f, val : controlchange( 0, , 127*val );
-/2/multipush1/3/1 f, val : controlchange( 0, 1-3, 127*val );
+/2/multipush1/1/1 f, val : controlchange( );
+/2/multipush1/2/1 f, val : controlchange( 0, 1, 127*val
+/2/multipush1/3/1 f, val : control change( 0, 1, 127*val );
 /2/multipush1/1/2 f, val controlchange( 0, 4, 127*val );
 /2/multipush1/2/2 f, val : controlchange( 0, 5, 127* 
 /2/multipush1/3/2 f, val : controlchange( 0, 6, 127*val ); junk

--- a/src/pair.c
+++ b/src/pair.c
@@ -226,19 +226,15 @@ void rm_whitespace(char* str)
 
    We parse the following syntax (in EBNF):
 
-   rule ::= path argtypes ',' oscarglist ':' command '(' midiarglist ')'
+   rule ::= path argtypes ',' [ arglist ] ':' command '(' arglist ')'
 
    path ::= OSC path string, must be non-empty
 
    argtypes ::= OSC type string, may be empty
 
-   oscarglist ::= [ [ oscarg ] { ',' [ oscarg ] } ]
+   arglist ::= [ arg ] { ',' [ arg ] }
 
-   oscarg ::= [ pre ] var [ post ] | number | number '-' number
-
-   arglist ::= arg { ',' arg }
-
-   arg ::= [ pre ] var [ post ] | number
+   arg ::= [ pre ] var [ post ] | number | number '-' number
 
    pre ::= '-' | [ number add-op ] [ number '*' ]
 
@@ -260,9 +256,6 @@ void rm_whitespace(char* str)
 
    In contrast, the parser is fairly picky about the argtypes string and only
    allows valid OSC type symbols there.
-
-   An empty arglist, empty arguments and ranges are permitted on the left-hand
-   side, but not on the right-hand side of a mapping rule.
 
    In order to provide good error-checking, the parser is also picky about the
    end of the line (anything which comes after the mapping rule). We only
@@ -310,9 +303,7 @@ char* check_arg(char* s, char delim, char **msg)
                     char op2 = *s;
                     if (op == '-' && (op2 == ',' || op2 == delim))
                     {
-                        // a range, this is only permitted on the lhs of a rule
-                        if (delim != ':')
-                            error_exit(*msg, "range is not allowed here");
+                        // a range
                         return s;
                     }
                     if (op2 != '*')
@@ -403,10 +394,8 @@ int check_config(char* config)
     if (!*s || *s==')') error_exit(msg, "expected midi arguments");
     while (*s && *s!=')')
     {
-        char *t = s;
         s = check_arg(s, ')', &msg);
         error_check(msg);
-        if (t == s) error_exit(msg, "expected midi argument");
         if (!*s || *s == ')') break;
         if (*s != ',') error_exit(msg, "expected ',' or ')'");
         s++;


### PR DESCRIPTION
Empty args and ranges are permitted on rhs of rules again, for consistency with the syntax of args on the lhs. Seems to be the right thing after all, and at least the ranges make perfect sense in reverse mappings.
