### PR TITLE
add -strict option + some bugfixes

### DIFF
--- a/maps/default.omm
+++ b/maps/default.omm
@@ -124,8 +124,10 @@
 #   /cow/1/moo fff, 2*a, a+3, a*100 : controlchange(channel, 10, a); 
 #   /bus/plugin/param2 i, val : controlchange(channel, val, val);
 # As you can see variables from one side are used several times on the other side.
-# If you expect messages to be converted both ways it is recommended that you use
-# strictly one to one mappings.
+# If you expect messages to be converted both ways it is better to use strictly
+# one to one mappings, since osc2midi does not normally check that multiple
+# occurrences of a variable are all matched to the same value. However, this can
+# be enforced by invoking osc2midi with the -strict option.
 
 # The important formatting details for each mapping are that the path and argment
 # types are separated by a space, the first comma indicates the first argument 

--- a/src/converter.h
+++ b/src/converter.h
@@ -15,6 +15,7 @@ typedef struct _CONVERTER
     uint8_t verbose;
     uint8_t mon_mode;
     uint8_t multi_match;
+    uint8_t strict_match;
     int8_t  convert; //0 = both, 1 = o2m, -1 = m2o
     uint8_t dry_run;
     int errors;

--- a/src/main.c
+++ b/src/main.c
@@ -212,6 +212,7 @@ void usage()
     printf("    -s <value>     set default filter shift value\n");
     printf("    -multi         multi mode (check all mappings/send multiple messages)\n");
     printf("    -single        multi mode off (stop checks after first match)\n");
+    printf("    -strict        strict matches (check multiple occurrences of variables)\n");
     printf("    -mon           only print OSC messages that come into the port\n");
     printf("    -o2m           only convert OSC messages to MIDI\n");
     printf("    -m2o           only convert MIDI messages to OSC\n");
@@ -221,9 +222,14 @@ void usage()
     printf("NOTES:\n");
     printf("    By default osc2midi looks for mapping files in /usr/local/share/osc2midi/.\n");
     printf("    See default.omm in that directory on how to create your own mappings.\n");
+    printf("\n");
     printf("    Multi mode is heavier: It finds all matches, which is useful if OSC\n");
     printf("    messages contain more data than can be sent in a single MIDI message.\n");
     printf("    By default multi mode is on. Pass -single to disable.\n");
+    printf("\n");
+    printf("    Strict matches make sure that multiple occurrences of a variable are all\n");
+    printf("    matched to the same value when converting an OSC or MIDI message. This\n");
+    printf("    incurs a small overhead and is disabled by default; -strict enables it.\n");
     printf("\n");
 
     return;
@@ -247,6 +253,7 @@ int main(int argc, char** argv)
     conv.errors = 0;
     conv.mon_mode = 0;
     conv.multi_match = 1;
+    conv.strict_match = 0;
     conv.glob_chan = 0;
     conv.glob_vel = 100;
     conv.filter = 0;
@@ -260,13 +267,18 @@ int main(int argc, char** argv)
         {
             if(strcmp(argv[i], "-single") ==0)
             {
-                //monitor mode (osc messages)
+                //single matches
                 conv.multi_match = 0;
             }
             else if(strcmp(argv[i], "-multi") ==0)
             {
-                //monitor mode (osc messages)
+                //multiple matches
                 conv.multi_match = 1;
+            }
+            else if(strcmp(argv[i], "-strict") ==0)
+            {
+                //strict matches
+                conv.strict_match = 1;
             }
             else if (strcmp(argv[i], "-map") == 0)
             {

--- a/src/main.c
+++ b/src/main.c
@@ -329,11 +329,15 @@ int main(int argc, char** argv)
             {
                 // global channel
                 conv.glob_chan = atoi(argv[++i]);
+		if(conv.glob_chan < 0) conv.glob_chan = 0;
+		if(conv.glob_chan > 15) conv.glob_chan = 15;
             }
             else if(strcmp(argv[i], "-vel") ==0)
             {
                 // global velocity
                 conv.glob_vel = atoi(argv[++i]);
+		if(conv.glob_vel < 0) conv.glob_vel = 0;
+		if(conv.glob_vel > 127) conv.glob_vel = 127;
             }
             else if(strcmp(argv[i], "-s") == 0)
             {

--- a/src/oscserver.c
+++ b/src/oscserver.c
@@ -86,7 +86,7 @@ int msg_handler(const char *path, const char *types, lo_arg ** argv,
     for(j=0; j<conv->npairs; j++)
     {
         PAIRHANDLE ph = conv->p[j];
-        if( (n = try_match_osc(ph,(char *)path,(char *)types,argv,argc,&(conv->glob_chan),&(conv->glob_vel),&(conv->filter),midi)) )
+        if( (n = try_match_osc(ph,(char *)path,(char *)types,argv,argc,conv->strict_match,&(conv->glob_chan),&(conv->glob_vel),&(conv->filter),midi)) )
         {
             if(!conv->multi_match)
                 j = conv->npairs;
@@ -140,7 +140,7 @@ void convert_midi_in(lo_address addr, CONVERTER* data)
         {
             PAIRHANDLE ph = data->p[i];
             oscm = lo_message_new();
-            if( (n = try_match_midi(ph, midi, &(data->glob_chan), path, oscm)) )
+            if( (n = try_match_midi(ph, midi, data->strict_match, &(data->glob_chan), path, oscm)) )
             {
                 if(!data->multi_match)
                     i = data->npairs;

--- a/src/pair.c
+++ b/src/pair.c
@@ -1306,7 +1306,7 @@ int try_match_osc(PAIRHANDLE ph, char* path, char* types, lo_arg** argv, int arg
                     //assert place==0 here
                     if(p->set_channel)
                     {
-                        msg[place+1] = ((uint8_t)conditioned)&0x7F;
+                        msg[place+1] = ((uint8_t)conditioned)&0x0F;
                     }
                     else if(p->set_velocity)
                     {
@@ -1416,7 +1416,7 @@ int try_match_osc(PAIRHANDLE ph, char* path, char* types, lo_arg** argv, int arg
                     //check if this is a message to set global channel etc.
                     if(p->set_channel)
                     {
-                        msg[place+1] = ((uint8_t)conditioned)&0x7F;
+                        msg[place+1] = ((uint8_t)conditioned)&0x0F;
                     }
                     else if(p->set_velocity)
                     {

--- a/src/pair.c
+++ b/src/pair.c
@@ -1734,7 +1734,13 @@ int try_match_midi(PAIRHANDLE ph, uint8_t msg[], uint8_t strict_match, uint8_t* 
         }
         else if(place != -1)
         {
-            float val = p->osc_scale[i]*(mymsg[place] - p->midi_offset[place]) / p->midi_scale[place] + p->osc_offset[i];
+            int midival = mymsg[place];
+            float val;
+            if(p->opcode == 0xE0 && place == 1)//pitchbend is special case (14 bit number)
+            {
+                midival += mymsg[place+1]*128;
+            }
+            val = p->osc_scale[i]*(midival - p->midi_offset[place]) / p->midi_scale[place] + p->osc_offset[i];
             //record the value for later use in reverse mapping -ag
             p->regs[i] = val;
             sprintf(chunk, p->path[i], (int)val);

--- a/src/pair.c
+++ b/src/pair.c
@@ -1229,7 +1229,7 @@ void free_pair(PAIRHANDLE ph)
 }
 
 //returns 1 if match is successful and msg has a message to be sent to the output
-int try_match_osc(PAIRHANDLE ph, char* path, char* types, lo_arg** argv, int argc, uint8_t* glob_chan, uint8_t* glob_vel, int8_t *filter, uint8_t msg[])
+int try_match_osc(PAIRHANDLE ph, char* path, char* types, lo_arg** argv, int argc, uint8_t strict_match, uint8_t* glob_chan, uint8_t* glob_vel, int8_t *filter, uint8_t msg[])
 {
     PAIR* p = (PAIR*)ph;
     //check the easy things first
@@ -1489,19 +1489,22 @@ int try_match_osc(PAIRHANDLE ph, char* path, char* types, lo_arg** argv, int arg
             p->regs[i+p->argc_in_path] = val;
         }
     }//for args
-    // Check for consistency of variable bindings.
-    for(i=0; i<p->argc+p->argc_in_path; i++)
+    if (strict_match)
     {
-        int j;
-        place = p->osc_map[i];
-        if(place != -1 && (j = p->midi_map[place]) != i)
+        // Check for consistency of variable bindings.
+        for(i=0; i<p->argc+p->argc_in_path; i++)
         {
-            // two different occurrences of the same variable on the lhs - check
-            // that their values are the same
-            float y1 = p->regs[i], y2 = p->regs[j];
-            float a1 = p->osc_scale[i], a2 = p->osc_scale[j];
-            float b1 = p->osc_offset[i], b2 = p->osc_offset[j];
-            if ((y1-b1)*a2 != (y2-b2)*a1) return 0;
+            int j;
+            place = p->osc_map[i];
+            if(place != -1 && (j = p->midi_map[place]) != i)
+            {
+                // two different occurrences of the same variable on the lhs - check
+                // that their values are the same
+                float y1 = p->regs[i], y2 = p->regs[j];
+                float a1 = p->osc_scale[i], a2 = p->osc_scale[j];
+                float b1 = p->osc_offset[i], b2 = p->osc_offset[j];
+                if ((y1-b1)*a2 != (y2-b2)*a1) return 0;
+            }
         }
     }
     // Handle setchannel et al. Note that the return value -1 doesn't indicate
@@ -1585,7 +1588,7 @@ int load_osc_value(lo_message oscm, char type, float val)
 }
 
 //see if incoming midi message matches this pair and create the associated OSC message
-int try_match_midi(PAIRHANDLE ph, uint8_t msg[], uint8_t* glob_chan, char* path, lo_message oscm)
+int try_match_midi(PAIRHANDLE ph, uint8_t msg[], uint8_t strict_match, uint8_t* glob_chan, char* path, lo_message oscm)
 {
     PAIR* p = (PAIR*)ph;
     uint8_t i,m[4] = {0,0,0,0}, noteon = 0;
@@ -1748,19 +1751,22 @@ int try_match_midi(PAIRHANDLE ph, uint8_t msg[], uint8_t* glob_chan, char* path,
         strcat(path, chunk);
     }
     strcat(path, p->path[i]);
-    // Check for consistency of variable bindings.
-    for(i=0; i<p->n; i++)
+    if (strict_match)
     {
-        int j;
-        place = p->midi_map[i];
-        if(place != -1 && (j = p->osc_map[place]) != i)
+        // Check for consistency of variable bindings.
+        for(i=0; i<p->n; i++)
         {
-            // two different occurrences of the same variable on the rhs - check
-            // that their values are the same
-            uint8_t y1 = mymsg[i], y2 = mymsg[j];
-            float a1 = p->midi_scale[i], a2 = p->midi_scale[j];
-            float b1 = p->midi_offset[i], b2 = p->midi_offset[j];
-            if ((y1-b1)*a2 != (y2-b2)*a1) return 0;
+            int j;
+            place = p->midi_map[i];
+            if(place != -1 && (j = p->osc_map[place]) != i)
+            {
+                // two different occurrences of the same variable on the rhs - check
+                // that their values are the same
+                uint8_t y1 = mymsg[i], y2 = mymsg[j];
+                float a1 = p->midi_scale[i], a2 = p->midi_scale[j];
+                float b1 = p->midi_offset[i], b2 = p->midi_offset[j];
+                if ((y1-b1)*a2 != (y2-b2)*a1) return 0;
+            }
         }
     }
 

--- a/src/pair.c
+++ b/src/pair.c
@@ -1320,6 +1320,11 @@ int try_match_osc(PAIRHANDLE ph, char* path, char* types, lo_arg** argv, int arg
                     {
                         msg[place+1] = ((uint8_t)conditioned);
                     }
+                    //put it in the midi message
+                    else if(place == 3)//only used for note on or off
+                    {
+                        msg[0] += ((uint8_t)(conditioned>0))<<4;
+                    }
                     else
                     {
                         //clamp MIDI values

--- a/src/pair.c
+++ b/src/pair.c
@@ -1306,11 +1306,15 @@ int try_match_osc(PAIRHANDLE ph, char* path, char* types, lo_arg** argv, int arg
                     //assert place==0 here
                     if(p->set_channel)
                     {
-                        msg[place+1] = ((uint8_t)conditioned)&0x7F;
+                        if(conditioned<0) conditioned = 0;
+                        if(conditioned>15) conditioned = 15;
+                        msg[place+1] = ((uint8_t)conditioned);
                     }
                     else if(p->set_velocity)
                     {
-                        msg[place+1] = ((uint8_t)conditioned)&0x7F;
+                        if(conditioned<0) conditioned = 0;
+                        if(conditioned>127) conditioned = 127;
+                        msg[place+1] = ((uint8_t)conditioned);
                     }
                     else if(p->set_shift)
                     {
@@ -1318,10 +1322,32 @@ int try_match_osc(PAIRHANDLE ph, char* path, char* types, lo_arg** argv, int arg
                     }
                     else
                     {
-                        msg[place] += ((uint8_t)conditioned)&0x7F;
+                        //clamp MIDI values
+                        // - 0..255 for status bytes (arg #0 of rawmidi)
+                        // - 0..15 for channel (arg #0 of other commands)
+                        // - 0..127 for regular data bytes
+                        // - 0..16383 for pitch bend
+                        if(conditioned<0) conditioned = 0;
                         if(p->opcode == 0xE0 && place == 1)//pitchbend is special case (14 bit number)
                         {
-                            msg[place+1] += ((uint8_t)(conditioned/128.0))&0x7F;
+                            if(conditioned>16383) conditioned = 16383;
+                            msg[place] += ((uint8_t)conditioned)&0x7F;
+                            msg[place+1] += ((uint8_t)(conditioned/128.0));
+                        }
+                        else if (place > 0) // ordinary data byte
+                        {
+                            if(conditioned>127) conditioned = 127;
+                            msg[place] += ((uint8_t)conditioned);
+                        }
+                        else if (p->raw_midi) // status byte
+                        {
+                            if(conditioned>255) conditioned = 255;
+                            msg[place] += ((uint8_t)conditioned);
+                        }
+                        else // channel
+                        {
+                            if(conditioned>15) conditioned = 15;
+                            msg[place] += ((uint8_t)conditioned);
                         }
                     }
                 }
@@ -1416,11 +1442,15 @@ int try_match_osc(PAIRHANDLE ph, char* path, char* types, lo_arg** argv, int arg
                     //check if this is a message to set global channel etc.
                     if(p->set_channel)
                     {
-                        msg[place+1] = ((uint8_t)conditioned)&0x7F;
+                        if(conditioned<0) conditioned = 0;
+                        if(conditioned>15) conditioned = 15;
+                        msg[place+1] = ((uint8_t)conditioned);
                     }
                     else if(p->set_velocity)
                     {
-                        msg[place+1] = ((uint8_t)conditioned)&0x7F;
+                        if(conditioned<0) conditioned = 0;
+                        if(conditioned>127) conditioned = 127;
+                        msg[place+1] = ((uint8_t)conditioned);
                     }
                     else if(p->set_shift)
                     {
@@ -1433,10 +1463,32 @@ int try_match_osc(PAIRHANDLE ph, char* path, char* types, lo_arg** argv, int arg
                     }
                     else
                     {
-                        msg[place] += ((uint8_t)conditioned)&0x7F;
+                        //clamp MIDI values
+                        // - 0..255 for status bytes (arg #0 of rawmidi)
+                        // - 0..15 for channel (arg #0 of other commands)
+                        // - 0..127 for regular data bytes
+                        // - 0..16383 for pitch bend
+                        if(conditioned<0) conditioned = 0;
                         if(p->opcode == 0xE0 && place == 1)//pitchbend is special case (14 bit number)
                         {
-                            msg[place+1] += ((uint8_t)(conditioned/128.0))&0x7F;
+                            if(conditioned>16383) conditioned = 16383;
+                            msg[place] += ((uint8_t)conditioned)&0x7F;
+                            msg[place+1] += ((uint8_t)(conditioned/128.0));
+                        }
+                        else if (place > 0) // ordinary data byte
+                        {
+                            if(conditioned>127) conditioned = 127;
+                            msg[place] += ((uint8_t)conditioned);
+                        }
+                        else if (p->raw_midi) // status byte
+                        {
+                            if(conditioned>255) conditioned = 255;
+                            msg[place] += ((uint8_t)conditioned);
+                        }
+                        else // channel
+                        {
+                            if(conditioned>15) conditioned = 15;
+                            msg[place] += ((uint8_t)conditioned);
                         }
                     }
                 }

--- a/src/pair.c
+++ b/src/pair.c
@@ -1306,7 +1306,7 @@ int try_match_osc(PAIRHANDLE ph, char* path, char* types, lo_arg** argv, int arg
                     //assert place==0 here
                     if(p->set_channel)
                     {
-                        msg[place+1] = ((uint8_t)conditioned)&0x0F;
+                        msg[place+1] = ((uint8_t)conditioned)&0x7F;
                     }
                     else if(p->set_velocity)
                     {
@@ -1416,7 +1416,7 @@ int try_match_osc(PAIRHANDLE ph, char* path, char* types, lo_arg** argv, int arg
                     //check if this is a message to set global channel etc.
                     if(p->set_channel)
                     {
-                        msg[place+1] = ((uint8_t)conditioned)&0x0F;
+                        msg[place+1] = ((uint8_t)conditioned)&0x7F;
                     }
                     else if(p->set_velocity)
                     {

--- a/src/pair.h
+++ b/src/pair.h
@@ -13,8 +13,8 @@ typedef void* PAIRHANDLE;
 PAIRHANDLE alloc_pair(char* config, table tab, float** regs, int* nkeys);
 void free_pair(PAIRHANDLE ph);
 int try_match_osc(PAIRHANDLE ph, char* path, char* types, lo_arg** argv, int argc,
-                  uint8_t* glob_chan, uint8_t* glob_vel, int8_t* filter, uint8_t msg[]);
-int try_match_midi(PAIRHANDLE ph, uint8_t msg[], uint8_t* glob_chan, char* path, lo_message oscm);
+                  uint8_t strict_match, uint8_t* glob_chan, uint8_t* glob_vel, int8_t* filter, uint8_t msg[]);
+int try_match_midi(PAIRHANDLE ph, uint8_t msg[], uint8_t strict_match, uint8_t* glob_chan, char* path, lo_message oscm);
 void print_pair(PAIRHANDLE ph);
 int check_pair_set_for_filter(PAIRHANDLE* pa, int npair);
 char * opcode2cmd(uint8_t opcode, uint8_t noteoff);


### PR DESCRIPTION
As promised. I think that it makes sense to keep the old behavior as the default. Thus handling of multiple occurrences of the same variable in matching is now disabled by default, but the new `-strict` option enables it.
