### PR TITLE
range too small for loop pair index

### DIFF
--- a/src/oscserver.c
+++ b/src/oscserver.c
@@ -127,7 +127,7 @@ int msg_handler(const char *path, const char *types, lo_arg ** argv,
 //client side
 void convert_midi_in(lo_address addr, CONVERTER* data)
 {
-    uint8_t i,n;
+    int i,n;
     uint8_t midi[3];
 
     while(pop_midi(data->seq,midi))
@@ -144,6 +144,7 @@ void convert_midi_in(lo_address addr, CONVERTER* data)
             {
                 if(!data->multi_match)
                     i = data->npairs;
+
                 if(data->verbose)
                 {
                     if(first)

--- a/src/oscserver.c
+++ b/src/oscserver.c
@@ -144,7 +144,6 @@ void convert_midi_in(lo_address addr, CONVERTER* data)
             {
                 if(!data->multi_match)
                     i = data->npairs;
-
                 if(data->verbose)
                 {
                     if(first)


### PR DESCRIPTION
Found one more. Testing the generated TouchOSC maps keeps shaking out the bugs...
