### PR TITLE
correct packaged install location

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 2.8)
 
 project (osc2midi)
 
-set(CMAKE_C_FLAGS "-Wall -g")
+set(CMAKE_C_FLAGS "-Wall -g -DPREFIX='\"${CMAKE_INSTALL_PREFIX}\"'")
 
 # check for our various libraries
 find_package(PkgConfig)

--- a/src/main.c
+++ b/src/main.c
@@ -16,6 +16,10 @@
 #include"jackdriver.h"
 #include"ht_stuff.h"
 
+#ifndef PREFIX
+#define PREFIX "/usr/local"
+#endif
+
 uint8_t quit = 0;
 
 void quitter(int sig)
@@ -108,18 +112,7 @@ int load_map(CONVERTER* conv, char* file)
     if(!map)
     {
         //try default install location
-        strcpy(path,"/usr/local/share/osc2midi/");
-        map = fopen(strcat(path,file),"r");
-    }
-    if(!map)
-    {
-        //try with extra .omm
-        map = fopen(strcat(path,".omm"),"r");
-    }
-    if(!map)
-    {
-        //try default packaged install location
-        strcpy(path,"/usr/share/osc2midi/");
+        strcpy(path,PREFIX "/share/osc2midi/");
         map = fopen(strcat(path,file),"r");
     }
     if(!map)

--- a/src/main.c
+++ b/src/main.c
@@ -119,7 +119,7 @@ int load_map(CONVERTER* conv, char* file)
     if(!map)
     {
         //try default packaged install location
-        strcpy(path,"/usr/local/share/osc2midi/");
+        strcpy(path,"/usr/share/osc2midi/");
         map = fopen(strcat(path,file),"r");
     }
     if(!map)


### PR DESCRIPTION
Found another one while testing the Arch package. Default install location and default packaged install location were the same, so osc2midi didn't find its map files when installed from the package.
