### PR TITLE
flush stdout after initial setup is finished

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -432,6 +432,7 @@ int main(int argc, char** argv)
 
     if(conv.verbose)
         printf("Ready.\n");
+    fflush(stdout);
 
     signal(SIGINT, quitter);
     while(!quit)


### PR DESCRIPTION
Added an fflush(stdout) after startup. This is a trivial and purely cosmetic change, but it makes the output look nicer with programs driving osc2midi (like my gosc2midi) when output goes to a pipe rather than the terminal.
