### PR TITLE
Bugfix, left-factoring of mapping rules.

### DIFF
--- a/src/pair.c
+++ b/src/pair.c
@@ -540,7 +540,6 @@ int get_pair_argtypes(char* config, char* path, PAIR* p, table tab, float** regs
         case 'F'://false
         case 'N'://nil
         case 'I'://infinity
-            p->osc_map[j] = -1;//initialize mapping to be not used
             p->types[j++] = argtypes[i];
             p->argc++;
         case ' ':
@@ -553,7 +552,7 @@ int get_pair_argtypes(char* config, char* path, PAIR* p, table tab, float** regs
     }
     p->types[j] = 0;//null terminate. It's good practice
     for(i=0; i<len+p->argc_in_path; i++)
-        p->osc_map[j] = -1;//initialize mapping for in-path args
+        p->osc_map[i] = -1;//initialize mapping for all args
     return 0;
 }
 


### PR DESCRIPTION
Commit 308b45b fixes a rather awful bug which probably got unveiled by commit 0d895bc, causing `osc_map` fields to remain uninitialized. I'd say that this is critical enough to warrant a new point release.

As a bonus, commit ee3ec6b lets you leave out the left-hand side osc message of a rule if it's the same as for the previous rule. This saves a lot of typing in cases where a single osc message maps to an entire collection of different midi messages. E.g.,

```
/multi/{i} ff, touch,x,y : controlchange( channel, touch, x*127);
/multi/{i} ff, touch,x,y : controlchange( channel, touch+10, y*127);
```

may now be written as:

```
/multi/{i} ff, touch,x,y : controlchange( channel, touch, x*127);
                         : controlchange( channel, touch+10, y*127);
```

(The whitespace at the beginning of the second line is purely cosmetic, of course.)

I'd say that this is rather convenient. The only downside is that an osc message path may not start with a colon any more, but I consider this rather unlikely anyway. What do you think?
