### PR TITLE
midi filter: poly aftertouch needs to be transposed as well

### DIFF
--- a/src/jackdriver.c
+++ b/src/jackdriver.c
@@ -347,6 +347,15 @@ process_midi_filter(JACK_SEQ* seq,jack_nframes_t nframes)
                         continue;
                     event.buffer[1] = note;
                 }
+                else if((event.buffer[0]&0xF0) == 0xA0)
+                {
+                    //polyphonic aftertouch event (just transpose)
+                    int note = event.buffer[1]+filter;
+                    if (note < 0 || note > 127)
+                        // note out of range, skip
+                        continue;
+                    event.buffer[1] = note;
+                }
 
             }
 


### PR DESCRIPTION
I already noticed this while working on rev. cbab4ae but then forgot about it. In the MIDI filter, polyphonic aftertouch messages need to be transposed along with note messages.

Note that the proposed change just transposes these messages, without trying to resend previous messages when the shift amount changes (as is the case with note messages). I think that this is good enough. Otherwise we'd have to keep track of the last aftertouch message for each sounding note, but I think that this is overkill for a transient effect like aftertouch, where we don't know how it's actually implemented on a given synthesizer (if at all).
